### PR TITLE
Fork the artifact server for stability in our act file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,32 @@
-.PHONY: build build-docker run debug run-docker
+.PHONY: build build-docker run debug run-docker poll-sqlite-size help test
 
-TAG := whylabs/whylogs:latest
+TAG := whylabs/whylogs:dev
 NAME := whylogs
 
-build:
+build: ## Build the service code locally.
 	./gradlew installDist
 
-test:
+test: ## Run unit tests.
 	./gradlew test
 
-build-docker:
+build-docker:build ## Build the service code into a docker container as whylabs/whylogs:dev.
 	docker build . -t $(TAG)
 
-run:
+run: ## Run the service code locally without Docker.
 	./gradlew run
 
-debug:
+debug: ## Run the service in debug mode so you can connect to it via remote JVM debugger.
 	./gradlew run --debug-java
 
-run-docker:
-	docker run -it --rm -p 127.0.0.1:5005:5005  -p 127.0.0.1:8080:8080 --env-file dev.env --name $(NAME) $(TAG)
+run-docker: ## Run the Docker container using a local.env file.
+	docker run -it --rm -p 127.0.0.1:5005:5005 -p 127.0.0.1:8080:8080 --env-file local.env --name $(NAME) $(TAG)
 
-poll-sqlite-size:
+poll-sqlite-size: ## If you run the service locally then this will echo info about the sqlite storage.
 	ls -1  /tmp/ | grep -e 'sqlite$$' | xargs -I{} bash -c "echo -n '{}:' && sqlite3 /tmp/{} 'select count(1) from items;'" && echo;
+
+help: ## Show this help message.
+	@echo 'usage: make [target] ...'
+	@echo
+	@echo 'targets:'
+	@cat ${MAKEFILE_LIST} | sed -n 's/^\(.\+\)\:.\+##\s\+\(.\+\)/\1 # \2/p' | sort | column -t -c 2 -s '#'
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+Image on [Docker Hub](https://hub.docker.com/repository/docker/whylabs/whylogs)
+
 ## Building Docker image
 
 * To build the docker image (locally):
@@ -131,20 +134,3 @@ docker exec -it whycontainer sh
 
 ngrep -q -W byline
 ```
-
-## Publishing the image
-
-You can use the `./publish_scripts/ecr-publish.mk` script to publish the container to our prod ECR. You'll have to make sure the IAM user that you use with the
-AWS CLI is allowed to push images by adding yourself to
-`https://console.aws.amazon.com/ecr/repositories/private/003872937983/whylogs-container/permissions/?region=us-east-1`.
-
-```
-./publish_scripts/ecr-publish.mk authenticate
-MAVEN_TOKEN=xxxxx ./publish_scripts/ecr-publish.mk publish
-```
-
-This will force a build at publish time to make sure that you're pushing the most recent image so you'll need to supply your `MAVEN_TOKEN` again. Images are
-tagged with the current date and time and they're visible at
-`https://console.aws.amazon.com/ecr/repositories/private/003872937983/whylogs-container?region=us-east-1`. We don't use a `latest` tag because AWS ECR's
-immutable tag feature doesn't permit it. The value of having immutable tags was higher than the convenience of being able to type `latest`, though it isn't
-clear why they don't make an exception for that popular convention.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
-
 Image on [Docker Hub](https://hub.docker.com/repository/docker/whylabs/whylogs)
+
+## Before Pushing
+
+You can test the Github CI by running `./build-scripts/act.sh` after you install [act](https://github.com/nektos/act). This will set up the artifact server that you need locally along side the act run, since the build depends on having one present.
+
+
+### act Setup
+
+- Create `~/.act-events.json` with this content: `{"act": true}` to enable skipping certain steps locally.
 
 ## Building Docker image
 
-* To build the docker image (locally):
+- To build the docker image (locally):
 
 ```
-gw installDist && docker build . -t whycontainer
+make build-docker
 ```
 
 ## Running the Docker image
 
-* You should prepare a `local.env` file in your workspace with the following content. Make sure you configure the heap to the appropriate size of your
-  container. The heap size also determines how many concurrent dataset profiles you can track at the same time (i.e. number of tag key-value combination)
+- You should prepare a `local.env` file in your workspace with the following content. Make sure you configure the heap to the appropriate size of your
+  container. The heap size also determines how many concurrent dataset profiles you can track at the same time (i.e. number of tag key-value combination). You can omit it for quick tests is the JVM defaults are fine of course.
 
 ```
 WHYLOGS_PERIOD=HOURS (default is HOURS if unspecified. Supported values: MINUTES, HOURS, DAYS)
@@ -32,7 +40,7 @@ WHYLABS_API_ENDPOINT=http://localhost:8080
 WHYLABS_API_KEY=xxxxxx
 
 # Each request to the container will have to provide an X-API-Key header with the
-# following value. 
+# following value.
 CONTAINER_API_KEY=secret-key
 
 # Required for uploading to whylabs. Specify an organization ID that is accessible with your WHYLABS_API_KEY.
@@ -53,18 +61,22 @@ REQUEST_QUEUEING_MODE=SQLITE #default
 REQUEST_QUEUEING_MODE=IN_MEMORY
 ```
 
-* Run the Docker image with the following command:
+- Run the Docker image with the following command:
 
 ```
 docker run -it --rm -p 127.0.0.1:8080:8080 --env-file local.env --name whycontainer whycontainer
 ```
 
-* Or run the service directly without docker
+- Or run the service directly without docker
 
 ```
-gw run
-gw run --debug-jvm
+make run
+
+# which just runs
+./gradlew run
 ```
+
+You can see a bunch of canned commands with `make help` as well. The makefile is essentially a list of canned commands for this repository.
 
 If you run it directly then you'll need to make sure the env variables are in your shell environment since docker isn't there to load them for you anymore.
 

--- a/build-scripts/act.sh
+++ b/build-scripts/act.sh
@@ -2,10 +2,10 @@
 
 # Startup the artifact server
 echo "Starting artifact server on 8080"
-docker run --rm -p 127.0.0.1:8080:8080 --env AUTH_KEY=foo --name artifact-server ghcr.io/jefuller/artifact-server:latest &
+docker run --rm -p 127.0.0.1:8080:8080 --env AUTH_KEY=foo --name artifact-server ghcr.io/whylabs/artifact-server:latest &
 
 # Run act
-act --env ACTIONS_CACHE_URL=http://localhost:8080/ --env ACTIONS_RUNTIME_URL=http://localhost:8080/ --env ACTIONS_RUNTIME_TOKEN=foo --env GITHUB_RUN_ID=$(date '+%s') --secret-file="$HOME/.act-secrets" || true
+act --env ACTIONS_CACHE_URL=http://localhost:8080/ --env ACTIONS_RUNTIME_URL=http://localhost:8080/ --env ACTIONS_RUNTIME_TOKEN=foo --env GITHUB_RUN_ID=$(date '+%s') --secret-file="$HOME/.act-secrets" -e "$HOME/.act-events.json" || true
 
 # Remove the artifact server
 echo "Shutting down artifact server"


### PR DESCRIPTION
The artifact server is broken in general right now localy for some
strnage reason. Our exported container tar just won't upload to it
correctly, despite other large files uploading correctly. Put too much
time in it for now so I'll have to circle back in the future. CI still
works properly, we just can't run act and expect passes locally
