### PR TITLE
Set package versions and remove user specification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY scripts/ /opt/whylogs/scripts/
 
 # Sqlite will come in handy for debugging if something goes terribly wrong. We use
 # a sqlite database to persist dataset profiles across server runs.
-RUN apk update && apk add --no-cache python3 supervisor sqlite ngrep
+RUN apk update && apk add --no-cache python3 supervisor=4.2.0-r0 sqlite=3.32.1-r1 ngrep
 
 EXPOSE 8080
 WORKDIR /opt/whylogs

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,5 @@
 [supervisord]
 nodaemon=true
-user=root
 
 [supervisorctl]
 serverurl=unix:///opt/whylogs/supervisor.sock


### PR DESCRIPTION
The package versions will ensure we don't pick up any new startup
behavior between builds. The removal of the user field brings it in line
with how we used to do things before migrating to github CI. I had added
this as a side effect of an error I was getting that I don't seem to be
getting anymore so if we don't need it then I'll just remove it.