### PR TITLE
Fix issue that caused errors to stop processing requests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,4 +70,5 @@ dependencies {
 
 application {
     mainClassName = "ai.whylabs.services.whylogs.MainKt"
+    applicationDefaultJvmArgs = listOf("-Dkotlinx.coroutines.debug")
 }

--- a/scripts/query-profiles.sh
+++ b/scripts/query-profiles.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-echo "Showing cached profiles"
-sqlite3 /tmp/profile-entries-map.sqlite 'select * from items;'
+# echo "Showing cached profiles"
+# sqlite3 /tmp/dataset-profiles-map-v2.sqlite 'select * from items;'
+
+echo -n "Cached profiles count:"
+sqlite3 /tmp/dataset-profiles-map-v2.sqlite 'select count(1) from items;'
 
 
-echo "Showing cached count of profiles"
-sqlite3 /tmp/profile-entries-map.sqlite 'select count(1) from items;'
+echo -n "Pending request count: "
+sqlite3 /tmp/pending-requests-queue-v2.sqlite 'select count(1) from items;'
+
+

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/EnvVars.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/EnvVars.kt
@@ -92,13 +92,16 @@ private fun requireIf(condition: Boolean, envName: String, fallback: String = ""
 // The right number for this entirely depends on the expected size of the requests and the memory on the machine.
 private fun parseQueueIncrement(): PopSize {
     val key = "REQUEST_QUEUE_PROCESSING_INCREMENT"
-    val increment = System.getenv(key) ?: "ALL"
-    if (increment == "ALL") {
+    // By default, set it to something large but finite. We have no idea how large the payloads
+    // are going to be and if this number is too big then we'll attempt to put all of that into
+    // memory at once, which could be bad.
+    val requestProcessingIncrement = System.getenv(key) ?: "100"
+    if (requestProcessingIncrement == "ALL") {
         return PopSize.All
     }
 
     try {
-        return PopSize.N(increment.toInt())
+        return PopSize.N(requestProcessingIncrement.toInt())
     } catch (t: Throwable) {
         throw IllegalStateException("Couldn't parse env key $key", t)
     }

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/WhyLogsController.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/WhyLogsController.kt
@@ -38,7 +38,9 @@ class WhyLogsController(
     }
 
     fun after(ctx: Context) {
-        profileManager.mergePending()
+        runBlocking {
+            profileManager.mergePending()
+        }
     }
 
     @OpenApi(

--- a/src/main/kotlin/ai/whylabs/services/whylogs/persistent/map/PersistentMap.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/persistent/map/PersistentMap.kt
@@ -2,34 +2,29 @@ package ai.whylabs.services.whylogs.persistent.map
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
-import java.util.concurrent.Executors
 
 /**
  * A map-like utility that immediately persists all of its contents to disk.
- * @param writer An implementation of [MapWriteLayer] to use for persistence.
  */
-class PersistentMap<K, V>(writer: MapWriteLayer<K, V>) : AutoCloseable {
+class PersistentMap<K, V>(options: MapMessageHandlerOptions<K, V>) {
     private val logger = LoggerFactory.getLogger(javaClass)
-
-    private val act =
-        mapMessageHandler(
-            MapMessageHandlerOptions(
-                CoroutineScope(Executors.newFixedThreadPool(2).asCoroutineDispatcher()),
-                writer
-            )
-        )
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val act = scope.mapMessageHandler(options)
 
     /**
      * Get an value from the map.
      * @return null if nothing exists for the key. Else, the associated value.
      */
     suspend fun get(key: K): V? {
-        val done = CompletableDeferred<V?>()
-        logger.debug("Sending get message and waiting for done signal")
-        act.send(PersistentMapMessage.GetMessage(done, key))
-        return done.await()
+        return withContext(scope.coroutineContext) {
+            val done = CompletableDeferred<V?>()
+            logger.debug("Sending get message and waiting for done signal")
+            act.send(PersistentMapMessage.GetMessage(done, key))
+            done.await()
+        }
     }
 
     /**
@@ -39,23 +34,25 @@ class PersistentMap<K, V>(writer: MapWriteLayer<K, V>) : AutoCloseable {
      * null indicates that the entry should be removed.
      */
     suspend fun set(key: K, block: suspend (V?) -> V?) {
-        val done = CompletableDeferred<V?>()
-        val processingDone = CompletableDeferred<V?>()
-        val currentItemDeferred = CompletableDeferred<V?>()
+        withContext(scope.coroutineContext) {
+            val done = CompletableDeferred<V?>()
+            val processingDone = CompletableDeferred<V?>()
+            val currentItemDeferred = CompletableDeferred<V?>()
 
-        logger.debug("Sending set message and waiting for done signal")
-        act.send(PersistentMapMessage.SetMessage(done, key, currentItemDeferred, processingDone))
+            logger.debug("Sending set message and waiting for done signal")
+            act.send(PersistentMapMessage.SetMessage(done, key, currentItemDeferred, processingDone))
 
-        val current = currentItemDeferred.await()
+            val current = currentItemDeferred.await()
 
-        try {
-            processingDone.complete(block(current))
-        } catch (t: Throwable) {
-            logger.error("Error while setting value for $key", t)
-            processingDone.completeExceptionally(t)
+            try {
+                processingDone.complete(block(current))
+            } catch (t: Throwable) {
+                logger.error("Error while setting value for $key", t)
+                processingDone.completeExceptionally(t)
+            }
+
+            done.await()
         }
-
-        done.await()
     }
 
     /**
@@ -64,30 +61,24 @@ class PersistentMap<K, V>(writer: MapWriteLayer<K, V>) : AutoCloseable {
      * The map that this block returns will turn into the new content.
      */
     suspend fun reset(block: suspend (Map<K, V>) -> Map<K, V>) {
-        val done = CompletableDeferred<V?>()
-        val everythingDeferred = CompletableDeferred<Map<K, V>>()
-        val processingDone = CompletableDeferred<Map<K, V>>()
+        withContext(scope.coroutineContext) {
+            val done = CompletableDeferred<V?>()
+            val everythingDeferred = CompletableDeferred<Map<K, V>>()
+            val processingDone = CompletableDeferred<Map<K, V>>()
 
-        act.send(PersistentMapMessage.ResetMessage(done, everythingDeferred, processingDone))
+            act.send(PersistentMapMessage.ResetMessage(done, everythingDeferred, processingDone))
 
-        logger.debug("Waiting for the current map state")
-        val everything = everythingDeferred.await()
+            logger.debug("Waiting for the current map state")
+            val everything = everythingDeferred.await()
 
-        try {
-            processingDone.complete(block(everything))
-        } catch (t: Throwable) {
-            logger.error("Error while resetting", t)
-            processingDone.completeExceptionally(t)
+            try {
+                processingDone.complete(block(everything))
+            } catch (t: Throwable) {
+                logger.error("Error while resetting", t)
+                processingDone.completeExceptionally(t)
+            }
+
+            done.await()
         }
-
-        done.await()
-    }
-
-    /**
-     * Close the map, making it no longer usable. You should close the map if you intend to create
-     * a new one to handle the same data for some reason.
-     */
-    override fun close() {
-        act.close()
     }
 }

--- a/src/main/kotlin/ai/whylabs/services/whylogs/persistent/queue/InMemoryQueueWriteLayer.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/persistent/queue/InMemoryQueueWriteLayer.kt
@@ -19,5 +19,5 @@ class InMemoryQueueWriteLayer<T> : QueueWriteLayer<T> {
         return queue.size
     }
 
-    override fun concurrentReadWrites() = false
+    override val concurrentReadWrites = false
 }

--- a/src/main/kotlin/ai/whylabs/services/whylogs/persistent/queue/QueueWriteLayer.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/persistent/queue/QueueWriteLayer.kt
@@ -6,7 +6,7 @@ interface QueueWriteLayer<T> {
      * concurrently. The queue handler will parallelize the incoming read/write requests
      * if this can support it. Otherwise, they will be serialized.
      */
-    fun concurrentReadWrites(): Boolean
+    val concurrentReadWrites: Boolean
     suspend fun push(t: List<T>)
     suspend fun peek(n: Int): List<T>
     suspend fun pop(n: Int)

--- a/src/main/kotlin/ai/whylabs/services/whylogs/persistent/queue/SqliteQueueWriteLayer.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/persistent/queue/SqliteQueueWriteLayer.kt
@@ -60,7 +60,7 @@ class SqliteQueueWriteLayer<T>(private val name: String, private val serializer:
     override suspend fun pop(n: Int) {
         // TODO this query is nicer and probably performs better but it requires sqlite to be built
         // with  SQLITE_ENABLE_UPDATE_DELETE_LIMIT flag.
-//        val query = "DELETE FROM items ORDER BY ROWID ASC LIMIT $n;"
+        // val query = "DELETE FROM items ORDER BY ROWID ASC LIMIT $n;"
         val query = "DELETE FROM items WHERE ROWID IN ( SELECT ROWID FROM items ORDER BY ROWID ASC LIMIT $n);"
         db {
             prepareStatement(query).executeUpdate()
@@ -85,5 +85,5 @@ class SqliteQueueWriteLayer<T>(private val name: String, private val serializer:
         return size ?: throw IllegalStateException("Couldn't get the size")
     }
 
-    override fun concurrentReadWrites() = true
+    override val concurrentReadWrites = true
 }

--- a/src/main/kotlin/ai/whylabs/services/whylogs/util/CoroutineUtil.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/util/CoroutineUtil.kt
@@ -1,0 +1,28 @@
+package ai.whylabs.services.whylogs.util
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.yield
+import org.slf4j.Logger
+
+suspend inline fun CoroutineScope.repeatUntilCancelled(log: Logger, block: () -> Unit) {
+    while (isActive) {
+        try {
+            block()
+            yield()
+        } catch (e: TimeoutCancellationException) {
+            // This doesn't actually count towards cancelling. We only want explicit cancels to
+            // break this loop.
+            log.info("coroutine on ${Thread.currentThread().name} timed out")
+        } catch (ex: CancellationException) {
+            log.info("coroutine on ${Thread.currentThread().name} cancelled")
+            throw ex
+        } catch (ex: Throwable) {
+            log.error("${Thread.currentThread().name} failed. Retrying...", ex)
+        }
+    }
+
+    log.info("coroutine on ${Thread.currentThread().name} exiting")
+}

--- a/src/main/kotlin/ai/whylabs/services/whylogs/util/LoggingUtil.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/util/LoggingUtil.kt
@@ -1,0 +1,15 @@
+package ai.whylabs.services.whylogs.util
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.lang.invoke.MethodHandles
+
+object LoggingUtil {
+
+    /**
+     * Util function for getting a loggert for a Kotlin file that has no top level class.
+     * It will end up using the class name of the generated Java class, which looks something
+     * like `FileNameKt`.
+     */
+    fun getLoggerForFile(): Logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+}

--- a/src/main/kotlin/ai/whylabs/services/whylogs/util/RetryOptions.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/util/RetryOptions.kt
@@ -1,0 +1,23 @@
+package ai.whylabs.services.whylogs.util
+
+import com.github.michaelbull.retry.policy.RetryPolicy
+import com.github.michaelbull.retry.policy.fullJitterBackoff
+import com.github.michaelbull.retry.policy.limitAttempts
+import com.github.michaelbull.retry.policy.plus
+import com.github.michaelbull.retry.retry
+
+val defaultRetryPolicy: RetryPolicy<Throwable> = limitAttempts(5) + fullJitterBackoff(base = 10, max = 1000)
+
+interface RetryOptions {
+    val retryPolicy: RetryPolicy<Throwable>?
+        get() = defaultRetryPolicy
+
+    suspend fun <T> retryIfEnabled(block: suspend () -> T): T {
+        val policy = this.retryPolicy
+        return if (policy == null) {
+            block()
+        } else {
+            retry(policy) { block() }
+        }
+    }
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -3,7 +3,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} [%-5level] [%logger{36}.%M()] - %msg%n}"/>
+            <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} [%level][%logger{1.}.%M()][%t t%tid] %msg%n}"/>
         </Console>
 
     </Appenders>
@@ -13,7 +13,6 @@
         </Logger>
 
         <Root level="all">
-            <AppenderRef ref="Console" level="warn"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/src/test/kotlin/ai/whylabs/services/whylogs/core/BufferedPersistentMapTest.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/core/BufferedPersistentMapTest.kt
@@ -3,10 +3,12 @@ package ai.whylabs.services.whylogs.core
 import ai.whylabs.services.whylogs.persistent.QueueBufferedPersistentMap
 import ai.whylabs.services.whylogs.persistent.QueueBufferedPersistentMapConfig
 import ai.whylabs.services.whylogs.persistent.Serializer
+import ai.whylabs.services.whylogs.persistent.map.MapMessageHandlerOptions
 import ai.whylabs.services.whylogs.persistent.map.PersistentMap
 import ai.whylabs.services.whylogs.persistent.map.SqliteMapWriteLayer
 import ai.whylabs.services.whylogs.persistent.queue.PersistentQueue
 import ai.whylabs.services.whylogs.persistent.queue.PopSize
+import ai.whylabs.services.whylogs.persistent.queue.QueueOptions
 import ai.whylabs.services.whylogs.persistent.queue.SqliteQueueWriteLayer
 import ai.whylabs.services.whylogs.persistent.serializer
 import kotlinx.coroutines.CompletableDeferred
@@ -26,20 +28,24 @@ class BufferedPersistentMapTest {
     @BeforeEach
     fun init() = runBlocking {
         queue = PersistentQueue(
-            SqliteQueueWriteLayer(
-                "test-queue",
-                StringSerializer()
+            QueueOptions(
+                SqliteQueueWriteLayer(
+                    "test-queue",
+                    StringSerializer()
+                )
             )
         )
         config = QueueBufferedPersistentMapConfig(
             queue = queue,
             map = PersistentMap(
-                SqliteMapWriteLayer(
-                    "test-map",
-                    StringSerializer(),
-                    IntSerializer()
+                MapMessageHandlerOptions(
+                    SqliteMapWriteLayer(
+                        "test-map",
+                        StringSerializer(),
+                        IntSerializer()
+                    )
                 ).apply {
-                    this.reset(emptyMap())
+                    writeLayer.reset(emptyMap())
                 }
             ),
             defaultValue = { 0 },
@@ -78,7 +84,6 @@ class BufferedPersistentMapTest {
         queue.pop(PopSize.All) {
             throw RuntimeException("This shouldn't be called because queuContent should be empty")
         }
-        bufferedMap.close()
     }
 
     @Test

--- a/src/test/kotlin/ai/whylabs/services/whylogs/core/WhyLogsProfileManagerTest.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/core/WhyLogsProfileManagerTest.kt
@@ -107,8 +107,6 @@ class WhyLogsProfileManagerTest {
         manager.config.queue.pop(PopSize.All) {
             throw RuntimeException("This shouldn't be called because queueContent should be empty")
         }
-
-        bufferedMap.close()
     }
 
     @Test
@@ -190,8 +188,6 @@ class WhyLogsProfileManagerTest {
         manager.config.queue.pop(PopSize.All) {
             throw RuntimeException("This shouldn't be called because queueContent should be empty")
         }
-
-        bufferedMap.close()
     }
 }
 

--- a/src/test/kotlin/ai/whylabs/services/whylogs/persistent/map/MapMessageHandlerTests.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/persistent/map/MapMessageHandlerTests.kt
@@ -1,0 +1,95 @@
+package ai.whylabs.services.whylogs.persistent.map
+
+import com.github.michaelbull.retry.policy.limitAttempts
+import io.mockk.coEvery
+import io.mockk.spyk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.lang.IllegalArgumentException
+
+class MapMessageHandlerTests {
+    @Test
+    fun `putting and getting values works`() = runBlocking {
+        val writeLayer = MockMapWriteLayer()
+        val map = PersistentMap(MapMessageHandlerOptions(writeLayer))
+        map.set("a") { "b" }
+        map.set("c") { "d" }
+
+        map.reset {
+            Assertions.assertEquals(mapOf("a" to "b", "c" to "d"), it)
+            it
+        }
+    }
+
+    @Test
+    fun `write layer recovers`() = runBlocking {
+        val writeLayer = spyk(MockMapWriteLayer())
+
+        coEvery { writeLayer.set(any(), any()) } throws (IllegalArgumentException("error")) andThenAnswer { callOriginal() }
+
+        val map = PersistentMap(MapMessageHandlerOptions(writeLayer, null))
+
+        // First one will throw
+        try {
+            map.set("a") { "b" }
+        } catch (t: Throwable) {
+        }
+
+        map.set("c") { "d" }
+
+        map.reset {
+            Assertions.assertEquals(mapOf("c" to "d"), it)
+            it
+        }
+    }
+
+    @Test
+    fun `retries work`() = runBlocking {
+        val writeLayer = spyk(MockMapWriteLayer())
+
+        coEvery { writeLayer.set(any(), any()) } throws (IllegalArgumentException("error")) andThenAnswer { callOriginal() }
+
+        val map = PersistentMap(MapMessageHandlerOptions(writeLayer, limitAttempts(2)))
+
+        // First one will throw but internal retries will recover
+        map.set("c") { "d" }
+
+        map.reset {
+            Assertions.assertEquals(mapOf("c" to "d"), it)
+            it
+        }
+    }
+}
+
+private class MockMapWriteLayer : MapWriteLayer<String, String> {
+    private var map = mutableMapOf<String, String>()
+
+    override suspend fun set(key: String, value: String) {
+        map[key] = value
+    }
+
+    override suspend fun get(key: String): String? {
+        return map[key]
+    }
+
+    override suspend fun getAll(): Map<String, String> {
+        return map
+    }
+
+    override suspend fun reset(to: Map<String, String>) {
+        map = mutableMapOf()
+    }
+
+    override suspend fun remove(key: String) {
+        map.remove(key)
+    }
+
+    override suspend fun size(): Int {
+        return map.size
+    }
+
+    override suspend fun clear() {
+        map.clear()
+    }
+}

--- a/src/test/kotlin/ai/whylabs/services/whylogs/persistent/map/PersistentMapTests.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/persistent/map/PersistentMapTests.kt
@@ -1,7 +1,6 @@
 package ai.whylabs.services.whylogs.persistent.map
 
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,13 +12,8 @@ class PersistentMapTests {
 
     @BeforeEach
     fun init() {
-        map = PersistentMap(writeLayer)
+        map = PersistentMap(MapMessageHandlerOptions(writeLayer))
         runBlocking { writeLayer.clear() }
-    }
-
-    @AfterEach
-    fun after() {
-        map.close()
     }
 
     @Test

--- a/src/test/kotlin/ai/whylabs/services/whylogs/persistent/queue/MockQueueWriteLayer.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/persistent/queue/MockQueueWriteLayer.kt
@@ -22,5 +22,5 @@ class MockQueueWriteLayer<T> : QueueWriteLayer<T> {
 
     override suspend fun size() = storage.size
 
-    override fun concurrentReadWrites() = false
+    override val concurrentReadWrites = false
 }

--- a/src/test/kotlin/ai/whylabs/services/whylogs/persistent/queue/QueueMessageHandlerTests.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/persistent/queue/QueueMessageHandlerTests.kt
@@ -1,8 +1,13 @@
 package ai.whylabs.services.whylogs.persistent.queue
 
 import ai.whylabs.services.whylogs.persistent.Serializer
+import com.github.michaelbull.retry.policy.limitAttempts
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.spyk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions
@@ -14,8 +19,124 @@ import java.nio.charset.Charset
 class QueueMessageHandlerTests {
 
     @Test
+    fun `queue recovers from errors in write layer pop`() = runBlocking {
+        val mockWriteLayer = spyk(MockQueueWriteLayer<String>())
+        val options = QueueOptions(mockWriteLayer, null)
+
+        // Make push throw once
+        coEvery { mockWriteLayer.pop(any()) } throws (IllegalArgumentException()) andThenAnswer { callOriginal() }
+
+        PersistentQueue(options).let { queue ->
+            queue.push(listOf("a", "b", "c"))
+
+            // will throw in the write layer
+            try {
+                queue.pop(PopSize.N(2)) { }
+            } catch (t: Throwable) {
+            }
+
+            queue.push(listOf("d"))
+
+            queue.pop(PopSize.N(4)) { items ->
+                Assertions.assertEquals(listOf("a", "b", "c", "d"), items)
+            }
+        }
+    }
+
+    @Test
+    fun `push and pop happen in parallel`() = runBlocking {
+        withTimeout(20_000) {
+            val mockWriteLayer = spyk(MockQueueWriteLayer<String>())
+            val options = QueueOptions(mockWriteLayer, limitAttempts(2))
+
+            every { mockWriteLayer.concurrentReadWrites } returns (true)
+            val queue = PersistentQueue(options)
+
+            val done = CompletableDeferred<Unit>()
+            launch {
+                queue.pop(PopSize.All) {
+                    // wait for the done signal. This would block push if concurrency didn't work
+                    done.await()
+                }
+            }
+
+            // These will execute even though pop is stalled
+            queue.push(listOf("a", "b", "c"))
+            queue.push(listOf("d"))
+
+            // Which we prove by using peek in the write layer which returns the things that
+            // have been saved to the queue. It isn't exposed through the PersistentQueue interface.
+            val items = mockWriteLayer.peek(10)
+            Assertions.assertEquals(listOf("a", "b", "c", "d"), items)
+
+            // Finally, finish the first pop
+            done.complete(Unit)
+        }
+    }
+
+    @Test
+    fun `queue retries failures`() = runBlocking {
+        val mockWriteLayer = spyk(MockQueueWriteLayer<String>())
+        val options = QueueOptions(mockWriteLayer, limitAttempts(2))
+
+        // Make push throw once
+        coEvery { mockWriteLayer.pop(any()) } throws (IllegalArgumentException()) andThenAnswer { callOriginal() }
+
+        PersistentQueue(options).let { queue ->
+            queue.push(listOf("a", "b", "c"))
+
+            // will throw in the write layer but the queue will retry over it and the error won't bubble up
+            // because it works on the second attempt
+            queue.pop(PopSize.N(4)) { items ->
+                Assertions.assertEquals(listOf("a", "b", "c"), items)
+            }
+        }
+    }
+
+    @Test
+    fun `queue retries failures as specified`() {
+        val mockWriteLayer = spyk(MockQueueWriteLayer<String>())
+        val options = QueueOptions(mockWriteLayer, limitAttempts(2))
+
+        // Make push throw once
+        coEvery { mockWriteLayer.push(any()) } throws (IllegalArgumentException())
+
+        PersistentQueue(options).let { queue ->
+            // It will throw more times than the retry count
+            Assertions.assertThrows(IllegalArgumentException::class.java) {
+                runBlocking {
+                    queue.push(listOf("a", "b", "c"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `queue recovers from errors in write layer push`() = runBlocking {
+        val mockWriteLayer = spyk(MockQueueWriteLayer<String>())
+        val options = QueueOptions(mockWriteLayer, null) // no retries
+
+        // Make push throw once
+        coEvery { mockWriteLayer.push(any()) } throws (IllegalArgumentException("mock throw")) andThenAnswer { callOriginal() }
+
+        PersistentQueue(options).let { queue ->
+            // will throw in the write layer
+            try {
+                queue.push(listOf("a", "b", "c"))
+            } catch (t: Throwable) {
+            }
+
+            queue.push(listOf("d"))
+
+            queue.pop(PopSize.N(4)) { items ->
+                Assertions.assertEquals(listOf("d"), items)
+            }
+        }
+    }
+
+    @Test
     fun `push and pop happy path`() = runBlocking {
-        PersistentQueue<String>(MockQueueWriteLayer()).use { queue ->
+        PersistentQueue<String>(QueueOptions(MockQueueWriteLayer())).let { queue ->
             queue.push(listOf("a", "b", "c"))
 
             queue.pop(PopSize.N(2)) { items ->
@@ -26,7 +147,7 @@ class QueueMessageHandlerTests {
 
     @Test
     fun `popping more than exist returns all`() = runBlocking {
-        PersistentQueue<String>(MockQueueWriteLayer()).use { queue ->
+        PersistentQueue<String>(QueueOptions(MockQueueWriteLayer())).let { queue ->
             queue.push(listOf("a", "b", "c"))
 
             queue.pop(PopSize.N(20)) { items ->
@@ -39,7 +160,7 @@ class QueueMessageHandlerTests {
     fun `popping doesn't block pushing`() = runBlocking {
         // If pop does block then this test will fail with a timeout
         withTimeout(5_000) {
-            PersistentQueue<String>(MockQueueWriteLayer()).use { queue ->
+            PersistentQueue<String>(QueueOptions(MockQueueWriteLayer())).let { queue ->
                 queue.push(listOf("a", "b", "c"))
 
                 val popDone = CompletableDeferred<Unit>()
@@ -60,7 +181,7 @@ class QueueMessageHandlerTests {
 
     @Test
     fun `throwing in pop doesn't break the queue or drop items`() = runBlocking {
-        PersistentQueue<String>(MockQueueWriteLayer()).use { queue ->
+        PersistentQueue<String>(QueueOptions(MockQueueWriteLayer())).let { queue ->
             queue.push(listOf("a", "b", "c"))
 
             // There should still be all 3 items left in the queue
@@ -90,12 +211,12 @@ class PersistentSqliteQueueTests {
     @BeforeEach
     fun init() = runBlocking {
         writer.clear()
-        queue = PersistentQueue(writer)
+        queue = PersistentQueue(QueueOptions(writer))
     }
 
     @Test
     fun `sqlite happy path`() = runBlocking {
-        queue.use {
+        queue.let {
             it.push(listOf("a", "b", "c"))
 
             it.pop(PopSize.N(2)) { items ->
@@ -110,7 +231,7 @@ class PersistentSqliteQueueTests {
 
     @Test
     fun `popping more than exist returns all`() = runBlocking {
-        queue.use {
+        queue.let {
             it.push(listOf("a", "b", "c"))
 
             it.pop(PopSize.N(20)) { items ->
@@ -121,7 +242,7 @@ class PersistentSqliteQueueTests {
 
     @Test
     fun `throwing pop doesn't break the queue or drop items`() = runBlocking {
-        queue.use {
+        queue.let {
             it.push(listOf("a", "b", "c"))
 
             // There should still be all 3 items left in the queue

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -3,7 +3,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} [%-5level] [%logger{36}.%M()] - %msg%n}"/>
+            <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} [%level][%logger{1.}.%M()][%t t%tid] %msg%n}"/>
         </Console>
 
     </Appenders>
@@ -13,7 +13,6 @@
         </Logger>
 
         <Root level="all">
-            <AppenderRef ref="Console" level="warn"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
The queue abstraction that we use ontop of sqlite wasn't able to recover
from errors when sqlite threw. Now it recovers.

We were getting a SQLite BUSY error which is technically possible since
we're allowing concurrent writes in the queue via pop/push, just rare
that the pop/push would happen at the same time. In anycase, we retry
for errors now and when things don't work out we won't die forever.

I refactored the layout of the queue actors so that they run on
their own threads when they're running in concurrent mode as well so
there is only one connection per thread at most.

Another useful change here is to the log format. I enabled coroutine
debugging and updated the format so that we'll see which coroutine
context, coroutine id, and thread id each message came from. That will
be very  useful when debugging some supposedly impossible error that
we're bound to get.