### PR TITLE
Several updates to improve debugging, small fixes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -58,6 +58,26 @@ jobs:
           name: container
           path: /tmp/whylogs-container.tar
 
+  preview-docs:
+    name: Generate a preview of the docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build docs
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: dokkaHtml
+
+      - name: "Deploy to Netlify"
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: build/dokka/html/
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1
+
   publish_docker_image:
     name: Publish the Docker image to Docker Hub
     if: ${{ !github.event.act && github.event_name == 'push' }}

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ fabric.properties
 /.run/
 *.env
 whylogs-profiles
+
+# Local Netlify folder
+.netlify

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ build-docker:build ## Build the service code into a docker container as whylabs/
 run: ## Run the service code locally without Docker.
 	./gradlew run
 
+docs: ## Generate dakka documentation
+	./gradlew dokkaHtml
+
 debug: ## Run the service in debug mode so you can connect to it via remote JVM debugger.
 	./gradlew run --debug-java
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     application
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
     id("com.adarshr.test-logger") version "3.2.0"
+    id("org.jetbrains.dokka") version "1.7.10"
 }
 group = "ai.whylabs.services"
 version = "1.0-SNAPSHOT"

--- a/src/integ/kotlin/ai/whylabs/services/whylogs/SmokeTests.kt
+++ b/src/integ/kotlin/ai/whylabs/services/whylogs/SmokeTests.kt
@@ -2,19 +2,35 @@ package ai.whylabs.services.whylogs
 
 import ai.whylabs.services.whylogs.core.LogRequest
 import ai.whylabs.services.whylogs.core.MultiLog
+import ai.whylabs.services.whylogs.core.config.EnvVars
 import ai.whylabs.services.whylogs.core.config.IEnvVars
 import ai.whylabs.services.whylogs.core.config.ProfileWritePeriod
 import ai.whylabs.services.whylogs.core.config.WriteLayer
 import ai.whylabs.services.whylogs.core.config.WriterTypes
 import ai.whylabs.services.whylogs.persistent.queue.PopSize
+import io.mockk.every
+import io.mockk.mockkObject
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class SmokeTests {
-    private val client = TestClient(TestEnvVars())
+
+    companion object {
+        private lateinit var client: TestClient
+
+        @BeforeAll
+        @JvmStatic
+        fun init() {
+            mockkObject(EnvVars)
+            val env = TestEnvVars()
+            every { EnvVars.instance } returns env
+            client = TestClient(env)
+        }
+    }
 
     @Test
     fun `writing profiles works`() = runBlocking {

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/DebugInfo.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/DebugInfo.kt
@@ -1,0 +1,108 @@
+package ai.whylabs.services.whylogs.core
+
+import ai.whylabs.services.whylogs.core.config.EnvVars
+import ai.whylabs.services.whylogs.core.config.IEnvVars
+import ai.whylabs.services.whylogs.objectMapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import java.util.Date
+
+private data class DebugInfo(
+    var env: IEnvVars,
+    var storedProfileCount: Int = 0,
+    var restLogCalls: Long = 0,
+    var profilesWritten: Long = 0,
+    var profilesWriteAttempts: Long = 0,
+    var lastProfileWriteSuccess: Date? = null,
+    var lastProfileWriteAttempt: Date? = null,
+    var kafkaMessagesHandled: Long = 0,
+    var startTime: Date = Date(),
+    var uptime: Date? = null
+)
+
+sealed class DebugInfoMessage {
+    class RestLogCalledMessage(val n: Int = 1) : DebugInfoMessage()
+    class KafkaMessagesHandledMessage(val n: Int = 1) : DebugInfoMessage()
+    class ProfileWrittenMessage(val n: Int = 1, val writeTime: Date = Date()) : DebugInfoMessage()
+    class ProfileWriteAttemptMessage(val n: Int = 1, val writeTime: Date = Date()) : DebugInfoMessage()
+    object LogMessage : DebugInfoMessage()
+}
+
+private val logger = LoggerFactory.getLogger(object {}::class.java.`package`.name)
+
+private fun CoroutineScope.debugActor(env: IEnvVars, profileStore: ProfileStore) = actor<DebugInfoMessage>(capacity = 1000) {
+    val info = DebugInfo(env = env)
+
+    suspend fun updateAndLog() {
+        val updated = info.copy(
+            uptime = Date(Date().time - info.startTime.time),
+            storedProfileCount = profileStore.profiles.map.size()
+        )
+
+        logger.info(objectMapper.writeValueAsString(updated))
+    }
+
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            runBlocking { updateAndLog() }
+        }
+    )
+
+    for (msg in channel) {
+        when (msg) {
+            is DebugInfoMessage.LogMessage -> updateAndLog()
+            is DebugInfoMessage.RestLogCalledMessage -> info.restLogCalls += msg.n
+            is DebugInfoMessage.KafkaMessagesHandledMessage -> info.kafkaMessagesHandled += msg.n
+            is DebugInfoMessage.ProfileWriteAttemptMessage -> {
+                info.profilesWriteAttempts += msg.n
+                info.lastProfileWriteAttempt = msg.writeTime
+            }
+            is DebugInfoMessage.ProfileWrittenMessage -> {
+                info.profilesWritten += msg.n
+                info.lastProfileWriteSuccess = msg.writeTime
+            }
+        }
+    }
+}
+
+class DebugInfoManager private constructor(
+    private val envVars: IEnvVars = EnvVars.instance,
+    profileStore: ProfileStore = ProfileStore.instance
+) {
+    private val debugInfo = CoroutineScope(Dispatchers.IO).debugActor(getEnv(), profileStore)
+    suspend fun send(msg: DebugInfoMessage) = debugInfo.send(msg)
+
+    private fun getEnv(): IEnvVars {
+        return object : IEnvVars {
+            override val writer = envVars.writer
+            override val whylabsApiEndpoint = envVars.whylabsApiEndpoint
+            override val orgId = envVars.orgId
+            override val ignoredKeys = envVars.ignoredKeys
+            override val fileSystemWriterRoot = envVars.fileSystemWriterRoot
+            override val emptyProfilesDatasetIds = envVars.emptyProfilesDatasetIds
+            override val requestQueueingMode = envVars.requestQueueingMode
+            override val requestQueueingEnabled = envVars.requestQueueingEnabled
+            override val profileStorageMode = envVars.profileStorageMode
+            override val requestQueueProcessingIncrement = envVars.requestQueueProcessingIncrement
+            override val whylogsPeriod = envVars.whylogsPeriod
+            override val s3Prefix = envVars.s3Prefix
+            override val s3Bucket = envVars.s3Bucket
+            override val port = envVars.port
+            override val debug = envVars.debug
+            override val kafkaConfig = envVars.kafkaConfig
+            override val profileWritePeriod = envVars.profileWritePeriod
+
+            // Omit passwords/secrets. Doing it like this is a bit verbose but it ensures that
+            // we won't mistakenly log new secrets we add to the env by mistake automatically.
+            override val whylabsApiKey = "--"
+            override val expectedApiKey = "--"
+        }
+    }
+
+    companion object {
+        val instance: DebugInfoManager by lazy { DebugInfoManager() }
+    }
+}

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/ProfileStore.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/ProfileStore.kt
@@ -1,0 +1,100 @@
+package ai.whylabs.services.whylogs.core
+
+import ai.whylabs.services.whylogs.core.config.EnvVars
+import ai.whylabs.services.whylogs.core.config.IEnvVars
+import ai.whylabs.services.whylogs.core.config.WriteLayer
+import ai.whylabs.services.whylogs.persistent.QueueBufferedPersistentMap
+import ai.whylabs.services.whylogs.persistent.QueueBufferedPersistentMapConfig
+import ai.whylabs.services.whylogs.persistent.map.InMemoryMapWriteLayer
+import ai.whylabs.services.whylogs.persistent.map.MapMessageHandlerOptions
+import ai.whylabs.services.whylogs.persistent.map.PersistentMap
+import ai.whylabs.services.whylogs.persistent.map.SqliteMapWriteLayer
+import ai.whylabs.services.whylogs.persistent.queue.InMemoryQueueWriteLayer
+import ai.whylabs.services.whylogs.persistent.queue.PersistentQueue
+import ai.whylabs.services.whylogs.persistent.queue.QueueOptions
+import ai.whylabs.services.whylogs.persistent.queue.SqliteQueueWriteLayer
+import com.whylogs.core.DatasetProfile
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class ProfileStore internal constructor(
+    private val envVars: IEnvVars = EnvVars.instance,
+    private val sessionId: String = UUID.randomUUID().toString(),
+) {
+    companion object {
+        val instance: ProfileStore by lazy { ProfileStore() }
+    }
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val queue = PersistentQueue(
+        QueueOptions(
+            queueWriteLayer = when (envVars.requestQueueingMode) {
+                WriteLayer.IN_MEMORY -> {
+                    logger.info("Using InMemoryWriteLayer for request queue.")
+                    InMemoryQueueWriteLayer()
+                }
+                WriteLayer.SQLITE -> {
+                    logger.info("Using SqliteQueueWriteLayer for request queue.")
+                    SqliteQueueWriteLayer("pending-requests", LogRequestSerializer())
+                }
+            }
+        )
+    )
+
+    private val map = PersistentMap(
+        MapMessageHandlerOptions(
+            when (envVars.profileStorageMode) {
+                WriteLayer.IN_MEMORY -> {
+                    logger.info("Using InMemoryWriteLayer for profile store.")
+                    InMemoryMapWriteLayer()
+                }
+                WriteLayer.SQLITE -> {
+                    logger.info("Using SqliteQueueWriteLayer for profile store.")
+                    SqliteMapWriteLayer(
+                        "dataset-profiles",
+                        ProfileKeySerializer(),
+                        ProfileEntrySerializer()
+                    )
+                }
+            }
+        )
+    )
+
+    internal val config = QueueBufferedPersistentMapConfig(
+        queue = queue,
+        map = map,
+        buffer = envVars.requestQueueingEnabled,
+        defaultValue = { profileKey ->
+            ProfileEntry(
+                profile = DatasetProfile(
+                    sessionId,
+                    profileKey.sessionTime,
+                    profileKey.windowStartTime,
+                    profileKey.normalizedTags.toMap() + mapOf(
+                        DatasetIdTag to profileKey.datasetId,
+                        OrgIdTag to profileKey.orgId
+                    ),
+                    mapOf()
+                ),
+                orgId = profileKey.orgId,
+                datasetId = profileKey.datasetId
+            )
+        },
+        groupByBlock = { bufferedLogRequest ->
+            ProfileKey.fromTags(
+                envVars.orgId,
+                bufferedLogRequest.request.datasetId,
+                bufferedLogRequest.request.tags ?: emptyMap(),
+                bufferedLogRequest.sessionTime,
+                bufferedLogRequest.windowStartTime
+            )
+        },
+        mergeBlock = { profile, logRequest ->
+            profile.profile.merge(logRequest.request, envVars.ignoredKeys)
+            profile
+        }
+    )
+
+    internal val profiles = QueueBufferedPersistentMap(config)
+}

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/RequestProfileUtil.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/RequestProfileUtil.kt
@@ -24,14 +24,16 @@ fun DatasetProfile.mergeNested(nestedValue: Map<String, Any>, ignored: Set<Strin
     }
 }
 
-fun DatasetProfile.merge(request: LogRequest, ignored: Set<String>) {
+fun DatasetProfile.merge(request: LogRequest, ignored: Set<String> = emptySet()) {
     request.single?.let { mergeNested(it, ignored) }
 
     request.multiple?.let {
         it.columns.forEachIndexed { i, featureName ->
             it.data.forEach { data ->
                 logger.debug("Merging $featureName into profile with timestamp $dataTimestamp")
-                track(featureName, data[i])
+                if (!ignored.contains(featureName)) {
+                    track(featureName, data[i])
+                }
             }
         }
     }

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVarNames.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVarNames.kt
@@ -22,11 +22,17 @@ enum class EnvVarNames(private val default: String? = null) {
     // container.profile_storage_mode
     PROFILE_STORAGE_MODE(WriteLayer.IN_MEMORY.name),
 
+    // container.file_system_writer_root
     FILE_SYSTEM_WRITER_ROOT("whylogs-profiles"),
 
     /**
-     * A JSON list of keys that should be ignored in Kafka data messages.
+     * A JSON list of keys that should be ignored when logging. If any of the columns of data messages
+     * match these keys then they won't be logged. Useful to avoid having to strip out data as
+     * a preprocessing step. If the container is running in Kafka mode then you can use this to avoid having
+     * to strip keys out of messages. If you're using the REST interface then any of the columns in the single
+     * or multiple will be dropped if they match any of the ones in here.
      */
+    // container.ignored_keys
     IGNORED_KEYS("[]"),
 
     //

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVars.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVars.kt
@@ -5,6 +5,7 @@ import ai.whylabs.services.whylogs.core.writer.S3Writer
 import ai.whylabs.services.whylogs.core.writer.WhyLabsWriter
 import ai.whylabs.services.whylogs.core.writer.Writer
 import ai.whylabs.services.whylogs.persistent.queue.PopSize
+import com.fasterxml.jackson.annotation.JsonIgnore
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
@@ -67,11 +68,8 @@ interface IEnvVars {
 
     val s3Prefix: String
     val s3Bucket: String
-
     val port: Int
     val debug: Boolean
-
-    // TODO aggregate the other options into namespaces like this
     val kafkaConfig: KafkaConfig?
 
     /**
@@ -82,6 +80,7 @@ interface IEnvVars {
      */
     val profileWritePeriod: ProfileWritePeriod
 
+    @JsonIgnore
     fun getProfileWriter(): Writer {
         return when (this.writer) {
             WriterTypes.S3 -> S3Writer(this)
@@ -111,7 +110,7 @@ class EnvVars private constructor() : IEnvVars {
     override val requestQueueProcessingIncrement = parseQueueIncrement()
 
     override val whylabsApiKey = EnvVarNames.WHYLABS_API_KEY.requireIf(writer == WriterTypes.WHYLABS)
-    override val expectedApiKey = EnvVarNames.CONTAINER_API_KEY.require()
+    override val expectedApiKey = EnvVarNames.CONTAINER_API_KEY.require().trim()
 
     // Just use a single writer until we get requests otherwise to simplify the error handling logic
     override val s3Prefix = EnvVarNames.S3_PREFIX.requireIf(writer == WriterTypes.S3)

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/writer/S3Writer.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/writer/S3Writer.kt
@@ -57,7 +57,7 @@ class S3Writer(private val envVars: IEnvVars = EnvVars.instance) : Writer {
             return WriteResult("s3", "s3://${envVars.s3Bucket}/$key")
         } catch (t: Throwable) {
             logger.error("Failed to upload profile to s3", t)
-            throw t // TODO why didn't I throw these before?
+            throw t
         }
     }
 }

--- a/src/main/kotlin/ai/whylabs/services/whylogs/main.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/main.kt
@@ -54,12 +54,9 @@ fun startServer(envVars: IEnvVars = EnvVars.instance): Javalin = try {
             ctx.json(e.message ?: "Bad Request").status(400)
         }
         routes {
-            path("logs") {
-                post(whylogs::track)
-            }
-            path("writeProfiles") {
-                post(whylogs::writeProfiles)
-            }
+            path("logs") { post(whylogs::track) }
+            path("writeProfiles") { post(whylogs::writeProfiles) }
+            path("logDebugInfo") { post(whylogs::logDebugInfo) }
         }
         after("logs", whylogs::after)
         // TODO make a call to list models to test the api key on startup as a health check

--- a/src/main/kotlin/ai/whylabs/services/whylogs/persistent/map/PersistentMap.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/persistent/map/PersistentMap.kt
@@ -29,6 +29,17 @@ class PersistentMap<K, V>(options: MapMessageHandlerOptions<K, V>) {
     }
 
     /**
+     * Get the number of entries.
+     */
+    suspend fun size(): Int {
+        return withContext(scope.coroutineContext) {
+            val done = CompletableDeferred<Int>()
+            act.send(PersistentMapMessage.SizeMessage(done))
+            done.await()
+        }
+    }
+
+    /**
      * Set a value for the given key.
      * @param block A block that will be passed the current value for the key. The
      * value that this block returns will be used as the new value for the key. Returning

--- a/src/test/kotlin/ai/whylabs/services/whylogs/core/RequestProfileUtilKtTest.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/core/RequestProfileUtilKtTest.kt
@@ -78,6 +78,80 @@ internal class RequestProfileUtilKtTest {
     }
 
     @Test
+    fun `ignoring keys work in multi logs`() {
+        val ignored = setOf("a", "b")
+        val profile = spyk(DatasetProfile("", Instant.ofEpochMilli(0)))
+        val actual = mutableMapOf<String, MutableList<Int>>()
+
+        val capturedFeature = slot<String>()
+        val capturedValue = slot<Int>()
+        every {
+            profile.track(capture(capturedFeature), capture(capturedValue))
+        } answers {
+            val value = capturedValue.captured
+            actual.compute(capturedFeature.captured) { _, current -> current?.apply { add(value) } ?: mutableListOf(value) }
+        }
+
+        val request = LogRequest(
+            datasetId = "1",
+            tags = null,
+            single = null,
+            multiple = MultiLog(
+                columns = listOf("a", "b", "c"),
+                data = listOf(
+                    listOf(1, 2, 3),
+                    listOf(4, 5, 6),
+                    listOf(7, 8, 9),
+                )
+            )
+        )
+
+        profile.merge(request, ignored)
+
+        val expected = mapOf("c" to listOf(3, 6, 9))
+        Assertions.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `ignoring keys work in multi logs when empty`() {
+        val ignored = setOf<String>()
+        val profile = spyk(DatasetProfile("", Instant.ofEpochMilli(0)))
+        val actual = mutableMapOf<String, MutableList<Int>>()
+
+        val capturedFeature = slot<String>()
+        val capturedValue = slot<Int>()
+        every {
+            profile.track(capture(capturedFeature), capture(capturedValue))
+        } answers {
+            val value = capturedValue.captured
+            actual.compute(capturedFeature.captured) { _, current -> current?.apply { add(value) } ?: mutableListOf(value) }
+        }
+
+        val request = LogRequest(
+            datasetId = "1",
+            tags = null,
+            single = null,
+            multiple = MultiLog(
+                columns = listOf("a", "b", "c"),
+                data = listOf(
+                    listOf(1, 2, 3),
+                    listOf(4, 5, 6),
+                    listOf(7, 8, 9),
+                )
+            )
+        )
+
+        profile.merge(request, ignored)
+
+        val expected = mapOf(
+            "a" to listOf(1, 4, 7),
+            "b" to listOf(2, 5, 8),
+            "c" to listOf(3, 6, 9)
+        )
+        Assertions.assertEquals(expected, actual)
+    }
+
+    @Test
     fun `ignoring nested keys work`() {
         val ignored = setOf("c.foo")
         val data = mapper.readValue<Map<String, Any>>(


### PR DESCRIPTION
First, the small fixes:
- Make IGNORED_KEYS work for the rest interface's `multiple` field as
well. It worked only for Kafka and the `single` field before.
- Trim API key whitespace. I ran into an issue where an API key wasn't
working because of this, which seemed silly.

The biggest update for debugging was the addition of a separate actor
that tracks a bunch of information that I find useful for debugging
issues, especially remotely. This debug state can be retrieved from logs
after the new API `logDebugInfo` is called, or after a shutdown. See the
`DebugInfo`file/class for the specific info collected.