### PR TITLE
Make auth header optional

### DIFF
--- a/src/integ/kotlin/ai/whylabs/services/whylogs/TestClient.kt
+++ b/src/integ/kotlin/ai/whylabs/services/whylogs/TestClient.kt
@@ -32,10 +32,7 @@ class TestClient(val envVars: IEnvVars) {
 
     suspend inline fun withServer(block: () -> Unit) {
         val job = startServer(envVars)
-
-        retry(policy) {
-            this.healthCheck()
-        }
+        retry(policy) { healthCheck() }
 
         try {
             deleteLocalProfiles()
@@ -69,7 +66,11 @@ class TestClient(val envVars: IEnvVars) {
                     GET()
                 }
             }
-            .header("X-API-Key", envVars.expectedApiKey)
+            .apply {
+                if (!envVars.disableAuth) {
+                    header("X-API-Key", envVars.expectedApiKey)
+                }
+            }
             .build()
         val response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString())
 

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/DebugInfo.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/DebugInfo.kt
@@ -80,6 +80,7 @@ private fun CoroutineScope.debugActor(options: DebugActorOptions) = actor<DebugI
                     info.profilesWriteFailureCauses.removeLast()
                 }
             }
+
             is DebugInfoMessage.ProfileWriteAttemptMessage -> {
                 info.profilesWriteAttempts += msg.n
                 info.lastProfileWriteAttempt = msg.writeTime
@@ -116,6 +117,7 @@ class DebugInfoManager internal constructor(
             override val ignoredKeys = envVars.ignoredKeys
             override val fileSystemWriterRoot = envVars.fileSystemWriterRoot
             override val emptyProfilesDatasetIds = envVars.emptyProfilesDatasetIds
+            override val disableAuth = envVars.disableAuth
             override val requestQueueingMode = envVars.requestQueueingMode
             override val requestQueueingEnabled = envVars.requestQueueingEnabled
             override val profileStorageMode = envVars.profileStorageMode

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVarNames.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVarNames.kt
@@ -19,6 +19,14 @@ enum class EnvVarNames(val default: String? = null) {
     EMPTY_PROFILE_DATASET_IDS("[]"),
 
     /**
+     * Disables the password auth header that the container uses to validate
+     * requests. Some integration paths make it difficult to send custom headers
+     * values and VPC privacy may be adequate for use cases as a substitute.
+     */
+    // container.disable_auth
+    DISABLE_AUTH("false"),
+
+    /**
      * A string password that the container requires for each request in
      * the `X-API-Key` header. This is a safeguard if you need to have
      * the container exposed to the internet or other untrusted sources.

--- a/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVars.kt
+++ b/src/main/kotlin/ai/whylabs/services/whylogs/core/config/EnvVars.kt
@@ -58,6 +58,7 @@ interface IEnvVars {
     val fileSystemWriterRoot: String
 
     val emptyProfilesDatasetIds: List<String>
+    val disableAuth: Boolean
     val requestQueueingMode: WriteLayer
     val requestQueueingEnabled: Boolean
 
@@ -107,6 +108,7 @@ class EnvVars private constructor() : IEnvVars {
     override val kafkaConfig = KafkaConfig.parse(this)
 
     override val emptyProfilesDatasetIds: List<String> = parseEnvList(EnvVarNames.EMPTY_PROFILE_DATASET_IDS)
+    override val disableAuth: Boolean = EnvVarNames.DISABLE_AUTH.getOrDefault().toBoolean()
     override val ignoredKeys: Set<String> = parseEnvList(EnvVarNames.IGNORED_KEYS).toSet()
 
     override val requestQueueingMode = WriteLayer.valueOf(EnvVarNames.REQUEST_QUEUEING_MODE.getOrDefault())

--- a/src/test/kotlin/ai/whylabs/services/whylogs/core/TestEnvVars.kt
+++ b/src/test/kotlin/ai/whylabs/services/whylogs/core/TestEnvVars.kt
@@ -13,6 +13,7 @@ class TestEnvVars : IEnvVars {
     override val orgId = "org-1"
     override val ignoredKeys: Set<String> = setOf()
     override val emptyProfilesDatasetIds = emptyList<String>()
+    override val disableAuth = false
     override val requestQueueingMode = WriteLayer.SQLITE
     override val requestQueueingEnabled = true
     override val profileStorageMode = WriteLayer.SQLITE


### PR DESCRIPTION
Apparently pubsub doesn't make it easy to pass along custom headers. This PR makes the auth header optional (default on) in case people are fine with just depending on their vpc for security, or whatever.